### PR TITLE
Add initial hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,31 @@
+# This configuration file allows our pre-commit hooks to be used with pre-commit: http://pre-commit.com/
+
+- id: terraform-fmt
+  name: Terraform fmt
+  description: Rewrites all Terraform configuration files to a canonical format.
+  entry: hooks/terraform-fmt.sh
+  language: script
+  files: \.tf$
+  exclude: \.+.terraform\/.*$
+
+- id: shellcheck
+  name: Shellcheck Bash Linter
+  description: Performs linting on bash scripts
+  entry: hooks/shellcheck.sh
+  language: script
+
+- id: gofmt
+  name: gofmt
+  description: Gofmt formats Go programs.
+  entry: hooks/gofmt.sh
+  language: script
+  files: \.go$
+  exclude: vendor\/.*$
+
+- id: golint
+  name: golint
+  description: Golint is a linter for Go source code.
+  entry: hooks/golint.sh
+  language: script
+  files: \.go$
+  exclude: vendor\/.*$

--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# Pre-commit hooks
+
+This repo defines Git pre-commit hooks intended for use with [pre-commit](http://pre-commit.com/). The currently
+supported hooks are:
+
+* **terraform-fmt**: Automatically run `terraform fmt` on all Terraform code (`*.tf` files).
+* **shellcheck**: Run [`shellcheck`](https://www.shellcheck.net/) to lint files that contain a bash [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix))
+* **gofmt**: Automatically run `gofmt` on all Goland code (`*.go` files).
+* **golint**: Automatically run `golint` on all Golang code (`*.go` files)
+
+
+
+
+## General Usage
+
+In each of your repos, add a file called `.pre-commit-config.yml` with the following contents:
+
+```yaml
+repos:
+  - repo: https://github.com/gruntwork-io/pre-commit
+    sha: <VERSION> # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
+    hooks:
+      - id: terraform-fmt
+      - id: shellcheck
+      - id: gofmt
+      - id: golint
+```
+
+Next, have every developer: 
+
+1. Install [pre-commit](http://pre-commit.com/). E.g. `brew install pre-commit`.
+1. Run `pre-commit install` in the repo.
+
+That’s it! Now every time you commit a code change (`.tf` file), the hooks in the `hooks:` config will execute.
+
+
+
+
+## Running Against All Files At Once
+
+
+### Example: Formatting all files
+
+If you'd like to format all of your code at once (rather than one file at a time), you can run:
+
+```bash
+pre-commit run terraform-fmt --all-files
+```
+
+
+
+### Example: Enforcing in CI
+
+If you'd like to enforce all your hooks, you can configure your CI build to fail if the code doesn't pass checks by
+adding the following to your build scripts:
+
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files
+```
+
+If all the hooks pass, the last command will exit with an exit code of 0. If any of the hooks make changes (e.g.,
+because files are not formatted), the last command will exit with a code of 1, causing the build to fail.

--- a/hooks/gofmt.sh
+++ b/hooks/gofmt.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# OSX GUI apps do not pick up environment variables the same way as Terminal apps and there are no easy solutions,
+# especially as Apple changes the GUI app behavior every release (see https://stackoverflow.com/q/135688/483528). As a
+# workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
+export PATH=$PATH:/usr/local/bin
+
+for file in "$@"; do
+  go fmt "$(dirname "$file")"
+done

--- a/hooks/golint.sh
+++ b/hooks/golint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+# OSX GUI apps do not pick up environment variables the same way as Terminal apps and there are no easy solutions,
+# especially as Apple changes the GUI app behavior every release (see https://stackoverflow.com/q/135688/483528). As a
+# workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
+export PATH=$PATH:/usr/local/bin
+
+exit_status=0
+
+for file in "$@"; do
+    if ! golint -set_exit_status "$file"; then
+        exit_status=1
+    fi
+done
+
+exit ${exit_status}

--- a/hooks/shellcheck.sh
+++ b/hooks/shellcheck.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+# OSX GUI apps do not pick up environment variables the same way as Terminal apps and there are no easy solutions,
+# especially as Apple changes the GUI app behavior every release (see https://stackoverflow.com/q/135688/483528). As a
+# workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
+export PATH=$PATH:/usr/local/bin
+
+exit_status=0
+
+for file in "$@"; do
+ if (head -1 "$file" |grep '^#!.*[sh]'>/dev/null); then
+
+    if ! shellcheck "$file"; then
+        exit_status=1
+    fi
+ elif [[ "$file" =~ \.sh$|bash$ ]]; then
+      echo "$file: missing shebang"
+      exit_status=1
+ fi
+done
+
+exit $exit_status

--- a/hooks/terraform-fmt.sh
+++ b/hooks/terraform-fmt.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# OSX GUI apps do not pick up environment variables the same way as Terminal apps and there are no easy solutions,
+# especially as Apple changes the GUI app behavior every release (see https://stackoverflow.com/q/135688/483528). As a
+# workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
+export PATH=$PATH:/usr/local/bin
+
+for file in "$@"; do
+  terraform fmt `dirname $file`
+done


### PR DESCRIPTION
This PR extracts pre-commit hooks we had in `module-ci` into an open source repo, so we can use these hooks with our other open source repos, such as Terratest.