### PR TITLE
Add yapf

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ supported hooks are:
 * **shellcheck**: Run [`shellcheck`](https://www.shellcheck.net/) to lint files that contain a bash [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix))
 * **gofmt**: Automatically run `gofmt` on all Golang code (`*.go` files).
 * **golint**: Automatically run `golint` on all Golang code (`*.go` files)
+* **yapf**: Automatically run [`yapf`](https://github.com/google/yapf) on all python code (`*.py` files).
 
 
 

--- a/hooks/yapf.sh
+++ b/hooks/yapf.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# OSX GUI apps do not pick up environment variables the same way as Terminal apps and there are no easy solutions,
+# especially as Apple changes the GUI app behavior every release (see https://stackoverflow.com/q/135688/483528). As a
+# workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
+export PATH=$PATH:/usr/local/bin
+
+readonly STYLE="{BASED_ON_STYLE: google, ALIGN_CLOSING_BRACKET_WITH_VISUAL_INDENT: true, COLUMN_LIMIT: 120, BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF: true, COALESCE_BRACKETS: false, DEDENT_CLOSING_BRACKETS: true, SPLIT_BEFORE_DOT: true, SPLIT_COMPLEX_COMPREHENSION: true}"
+
+for file in "$@"; do
+  if [[ "$file" =~ \.py$ ]]; then
+    yapf -ri --style="$STYLE" "$(dirname "$file")"
+  fi
+done


### PR DESCRIPTION
This adds a precommit hook for python files using [`yapf`](https://github.com/google/yapf), the google python formatter. I also preselected a few options based on what I usually use.