### PR TITLE
Fix exclusion

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -44,4 +44,8 @@
   entry: hooks/yapf.sh
   language: script
   files: \.py$
-  exclude: __pycache__\/.*$
+  exclude: >
+    (?x)^(
+      \.tox\/.*$|
+      __pycache__\/.*$
+    )$

--- a/hooks/yapf.sh
+++ b/hooks/yapf.sh
@@ -11,6 +11,6 @@ readonly STYLE="{BASED_ON_STYLE: google, ALIGN_CLOSING_BRACKET_WITH_VISUAL_INDEN
 
 for file in "$@"; do
   if [[ "$file" =~ \.py$ ]]; then
-    yapf -ri --style="$STYLE" "$(dirname "$file")"
+    yapf -ri --style="$STYLE" "$file"
   fi
 done


### PR DESCRIPTION
I ran into some issues in the new yapf hook where it picked up files in `.tox`, which is the multi python version unit test runner.

This updates the exclusions to exclude the folders correctly.