### PR TITLE
Helmlint supports required values

### DIFF
--- a/hooks/helmlint.sh
+++ b/hooks/helmlint.sh
@@ -123,7 +123,7 @@ for file in "$@"; do
     if contains_element "$file_chart_path" "${seen_chart_paths[@]}"; then
       debug "Already linted $file_chart_path"
     else
-      helm lint "$file_chart_path"
+      helm lint -f "$linter_values" "$file_chart_path"
       seen_chart_paths+=( "$file_chart_path" )
     fi
   fi

--- a/hooks/helmlint.sh
+++ b/hooks/helmlint.sh
@@ -112,18 +112,22 @@ for file in "$@"; do
 
   # The chart values.yaml file may not have all the values defined to enforce default values, which will cause the
   # linter to fail. To support this, this pre-commit hook looks for a special values file called `linter_values.yaml`
-  # which should define all the values that will be fed to the linter.
+  # which should define the additional values that will be fed to the linter.
   if [[ -f "$file_chart_path/linter_values.yaml" ]]; then
-    linter_values="$file_chart_path/linter_values.yaml"
+    linter_values_arg="$file_chart_path/linter_values.yaml"
   else
-    linter_values="$file_chart_path/values.yaml"
+    linter_values_arg=""
   fi
 
   if [[ ! -z "$file_chart_path" ]]; then
     if contains_element "$file_chart_path" "${seen_chart_paths[@]}"; then
       debug "Already linted $file_chart_path"
+    elif [[ -z "$linter_values_arg" ]]; then
+      helm lint "$file_chart_path"
+      seen_chart_paths+=( "$file_chart_path" )
     else
-      helm lint -f "$linter_values" "$file_chart_path"
+      # Combine both linter_values.yaml and values.yaml
+      helm lint -f "$file_chart_path/values.yaml" -f "$linter_values_arg" "$file_chart_path"
       seen_chart_paths+=( "$file_chart_path" )
     fi
   fi

--- a/hooks/helmlint.sh
+++ b/hooks/helmlint.sh
@@ -110,6 +110,15 @@ for file in "$@"; do
   file_chart_path=$(chart_path "$file")
   debug "Resolved $file to chart path $file_chart_path"
 
+  # The chart values.yaml file may not have all the values defined to enforce default values, which will cause the
+  # linter to fail. To support this, this pre-commit hook looks for a special values file called `linter_values.yaml`
+  # which should define all the values that will be fed to the linter.
+  if [[ -f "$file_chart_path/linter_values.yaml" ]]; then
+    linter_values="$file_chart_path/linter_values.yaml"
+  else
+    linter_values="$file_chart_path/values.yaml"
+  fi
+
   if [[ ! -z "$file_chart_path" ]]; then
     if contains_element "$file_chart_path" "${seen_chart_paths[@]}"; then
       debug "Already linted $file_chart_path"


### PR DESCRIPTION
Ran into another edge case with `helm lint`. See [the README changes](https://github.com/gruntwork-io/pre-commit/blob/04de99a5a551a2221c2885f6166bf8ef276c7da8/README.md#linter_valuesyaml) for an explanation.