### PR TITLE
Fix incorrect shebang detection

### DIFF
--- a/hooks/shellcheck.sh
+++ b/hooks/shellcheck.sh
@@ -10,7 +10,7 @@ export PATH=$PATH:/usr/local/bin
 exit_status=0
 
 for file in "$@"; do
- if (head -1 "$file" |grep '^#!.*[sh]'>/dev/null); then
+ if (head -1 "$file" |grep '^#!.*sh'>/dev/null); then
 
     if ! shellcheck "$file"; then
         exit_status=1


### PR DESCRIPTION
The Shellcheck hook incorrectly detects shebangs for [bats](https://github.com/sstephenson/bats) as being shell scripts. These are not handled by shellcheck and lead to the checks failing (when they should not).

The shebang for .bats files looks like this:

```sh
#!/usr/bin/env bats
```

The attached pull request fixes the shebang detection for all cases where it's relevant to me; I can't think of a reasonable breakage case but let me know if you see problems.