### PR TITLE
Fix gofmt hook

### DIFF
--- a/hooks/gofmt.sh
+++ b/hooks/gofmt.sh
@@ -7,6 +7,7 @@ set -e
 # workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
 export PATH=$PATH:/usr/local/bin
 
+
 for file in "$@"; do
-  go fmt "$(dirname "$file")"
+  go fmt "./$(dirname "$file")"
 done


### PR DESCRIPTION
This fixes the `gofmt` hook. The main issue is that this is using a relative path without the prefix `./`, which throws off go because it will look for the package in `GOPATH` directly, as opposed to treating it like a file package in the current directory.