### PR TITLE
Markdown link check

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -74,3 +74,11 @@
   entry: hooks/helmlint.sh
   language: script
   files: \.((ya?ml)|(tpl))$
+
+- id: markdown-link-check
+  name: markdown-link-check
+  description: Run markdown-link-check to check all the relative and absolute links in markdown docs.
+  entry: hooks/mdlink-check.sh
+  language: script
+  files: \.md$
+  exclude: vendor\/.*$

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ supported hooks are:
 * **golint**: Automatically run `golint` on all Golang code (`*.go` files)
 * **yapf**: Automatically run [`yapf`](https://github.com/google/yapf) on all python code (`*.py` files).
 * **helmlint** Automatically run [`helm lint`](https://github.com/helm/helm/blob/master/docs/helm/helm_lint.md) on your
-  helm charts.
+* **markdown-link-check** Automatically run [markdown-link-check](https://github.com/tcort/markdown-link-check) on
+  markdown doc files.
 
 
 

--- a/hooks/mdlink-check.sh
+++ b/hooks/mdlink-check.sh
@@ -7,6 +7,12 @@ set -e
 # workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
 export PATH=$PATH:/usr/local/bin
 
+if ! command -v markdown-link-check; then
+  >&2 echo "markdown-link-check is not available on this system."
+  >&2 echo "Please install it by running 'npm install -g markdown-link-check'"
+  exit 1
+fi
+
 TMP_CONFIG="$(mktemp)"
 cat > "$TMP_CONFIG" <<EOF
 {

--- a/hooks/mdlink-check.sh
+++ b/hooks/mdlink-check.sh
@@ -13,7 +13,7 @@ cat > "$TMP_CONFIG" <<EOF
   "replacementPatterns": [
     {
       "pattern": "^/",
-      "replacement": "file://$(pwd)"
+      "replacement": "file://$(pwd)/"
     }
   ]
 }

--- a/hooks/mdlink-check.sh
+++ b/hooks/mdlink-check.sh
@@ -13,6 +13,8 @@ if ! command -v markdown-link-check; then
   exit 1
 fi
 
+# This is the recommended way to set the project root for properly resolving absolute paths. See
+# https://github.com/tcort/markdown-link-check/issues/16 for more info.
 TMP_CONFIG="$(mktemp)"
 cat > "$TMP_CONFIG" <<EOF
 {

--- a/hooks/mdlink-check.sh
+++ b/hooks/mdlink-check.sh
@@ -19,4 +19,6 @@ cat > "$TMP_CONFIG" <<EOF
 }
 EOF
 
-markdown-link-check -c "$TMP_CONFIG" "$(pwd)"
+for file in "$@"; do
+  markdown-link-check -c "$TMP_CONFIG" "$file"
+done

--- a/hooks/mdlink-check.sh
+++ b/hooks/mdlink-check.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+# OSX GUI apps do not pick up environment variables the same way as Terminal apps and there are no easy solutions,
+# especially as Apple changes the GUI app behavior every release (see https://stackoverflow.com/q/135688/483528). As a
+# workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
+export PATH=$PATH:/usr/local/bin
+
+TMP_CONFIG="$(mktemp)"
+cat > "$TMP_CONFIG" <<EOF
+{
+  "replacementPatterns": [
+    {
+      "pattern": "^/",
+      "replacement": "file://$(pwd)"
+    }
+  ]
+}
+EOF
+
+markdown-link-check -c "$TMP_CONFIG"

--- a/hooks/mdlink-check.sh
+++ b/hooks/mdlink-check.sh
@@ -19,4 +19,4 @@ cat > "$TMP_CONFIG" <<EOF
 }
 EOF
 
-markdown-link-check -c "$TMP_CONFIG"
+markdown-link-check -c "$TMP_CONFIG" "$(pwd)"


### PR DESCRIPTION
This is a pre-commit hook that can be used to check links on markdown docs, using the npm package [markdown-link-check](https://www.npmjs.com/package/markdown-link-check).