### PR TITLE
Fix terraform fmt hook where it is now running on all files regardless of exclude

### DIFF
--- a/hooks/terraform-fmt.sh
+++ b/hooks/terraform-fmt.sh
@@ -8,7 +8,5 @@ set -e
 export PATH=$PATH:/usr/local/bin
 
 for file in "$@"; do
-  tmp_file="$(mktemp)"
-  terraform fmt - <"$file" >"$tmp_file"
-  mv "$tmp_file" "$file"
+  terraform fmt -write=true "$file"
 done

--- a/hooks/terraform-fmt.sh
+++ b/hooks/terraform-fmt.sh
@@ -7,4 +7,8 @@ set -e
 # workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
 export PATH=$PATH:/usr/local/bin
 
-terraform fmt -recursive
+for file in "$@"; do
+  tmp_file="$(mktemp)"
+  terraform fmt - <"$file" >"$tmp_file"
+  mv "$tmp_file" "$file"
+done


### PR DESCRIPTION
This fixes a bug with our terraform fmt hook that was introduced in https://github.com/gruntwork-io/pre-commit/pull/15.

Specifically, `terraform fmt -r` ignores the exclude configuration. This makes it hard for our repos that are testing malformed terraform files as they will never pass the `terraform fmt` precommit hook.

Instead, we go through each file to run through `terraform fmt`.