### PR TITLE
Terragrunt hclfmt hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -26,6 +26,18 @@
   files: \.tf$
   exclude: \.+.terraform\/.*$
 
+- id: terragrunt-hclfmt
+  name: Terragrunt hclfmt
+  description: Rewrites all Terragrunt configuration files to a canonical format
+  entry: hooks/terragrunt-hclfmt.sh
+  language: script
+  files: \.hcl$
+  exclude: >
+    (?x)^(
+      .+\.terraform\/.*$|
+      .+\.terragrunt-cache\/.*$|
+    )$
+
 - id: shellcheck
   name: Shellcheck Bash Linter
   description: Performs linting on bash scripts

--- a/hooks/terragrunt-hclfmt.sh
+++ b/hooks/terragrunt-hclfmt.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# OSX GUI apps do not pick up environment variables the same way as Terminal apps and there are no easy solutions,
+# especially as Apple changes the GUI app behavior every release (see https://stackoverflow.com/q/135688/483528). As a
+# workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
+export PATH=$PATH:/usr/local/bin
+
+for file in "$@"; do
+  terragrunt hclfmt --terragrunt-config "$file"
+done

--- a/hooks/terragrunt-hclfmt.sh
+++ b/hooks/terragrunt-hclfmt.sh
@@ -8,5 +8,5 @@ set -e
 export PATH=$PATH:/usr/local/bin
 
 for file in "$@"; do
-  terragrunt hclfmt --terragrunt-config "$file"
+  terragrunt hclfmt --terragrunt-hclfmt-file "$file"
 done


### PR DESCRIPTION
This is a pre-commit hook to ensure that `terragrunt hclfmt` is run on all the `.hcl` files in a repo.