### PR TITLE
Shellcheck optionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,19 @@ Now when the pre-commit hook runs, it will call `helm lint` with both `linter_va
 helm lint -f values.yaml -f linter_values.yaml .
 ```
 
+## Shellcheck Arguments
+
+To enable optional shellcheck features you can use the `--enable` flag.
+Other shellcheck flags can not be passed through.
+
+```yaml
+repos:
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: <VERSION>
+    hooks:
+      - id: shellcheck
+        args: ["--enable require-variable-braces,deprecate-which"]
+```
 
 
 ## License

--- a/hooks/shellcheck.sh
+++ b/hooks/shellcheck.sh
@@ -8,47 +8,42 @@ set -e
 export PATH=$PATH:/usr/local/bin
 
 exit_status=0
-ENABLE_LIST=""
+enable_list=""
 
-# Arguments
 parse_arguments() {
-  while [ $# -gt 0 ]; do
-    # Get param and value using parameter expansion, splitting on = or " "
-    param="${1%[ =]*}"
-    value="${1#*[ =]}"
-    if [ "$param" = "$value" ]; then value="$2"; fi
-    shift
-    case "$param" in
-    --enable)
-      ENABLE_LIST="$ENABLE_LIST $value"
-      ;;
-    -*)
-      echo "Error: Unknown option: $param" >&2
-      exit 1
-      ;;
-    *)
-      PARAMS="$PARAMS $param"
-      ;;
-    esac
-  done
-  ENABLE_LIST="${ENABLE_LIST## }" # remove preceeding space
+	while (($# > 0)); do
+		# Grab param and value splitting on " " or "=" with parameter expansion
+		local PARAMETER="${1%[ =]*}"
+		local VALUE="${1#*[ =]}"
+		if [[ "$PARAMETER" == "$VALUE" ]]; then VALUE="$2"; fi
+		shift
+		case "$PARAMETER" in
+		--enable)
+			enable_list="$enable_list $VALUE"
+			;;
+		-*)
+			echo "Error: Unknown option: $PARAMETER" >&2
+			exit 1
+			;;
+		*)
+			files="$files $PARAMETER"
+			;;
+		esac
+	done
+	enable_list="${enable_list## }" # remove preceeding space
 }
 
 parse_arguments "$@"
 
-for file in $PARAMS; do
-  if (head -1 "$file" | grep '^#!.*sh'>/dev/null); then
-    SHELLCHECK_ARGS=""
-    if [ "$ENABLE_LIST" != "" ]; then
-      SHELLCHECK_ARGS+="--enable=\"$ENABLE_LIST\" "
-    fi
-    if ! eval "shellcheck $SHELLCHECK_ARGS\"$file\""; then
-      exit_status=1
-    fi
-  elif [[ "$file" =~ \.sh$|bash$ ]]; then
-    echo "$file: missing shebang"
-    exit_status=1
-  fi
+for FILE in $files; do
+	if (head -1 "$FILE" | grep '^#!.*sh' >/dev/null); then
+		if ! shellcheck ${enable_list:+ --enable="$enable_list"} "$FILE"; then
+			exit_status=1
+		fi
+	elif [[ "$FILE" =~ \.sh$|bash$ ]]; then
+		echo "$FILE: missing shebang"
+		exit_status=1
+	fi
 done
 
 exit $exit_status

--- a/hooks/shellcheck.sh
+++ b/hooks/shellcheck.sh
@@ -36,11 +36,12 @@ parse_arguments() {
 parse_arguments "$@"
 
 for FILE in $files; do
-	if (head -1 "$FILE" | grep '^#!.*sh' >/dev/null); then
+	SHEBANG_REGEX='^#!\(/\|/.*/\|/.* \)\(\(ba\|da\|k\|a\)*sh\|bats\)$'
+	if (head -1 "$FILE" | grep "$SHEBANG_REGEX" >/dev/null); then
 		if ! shellcheck ${enable_list:+ --enable="$enable_list"} "$FILE"; then
 			exit_status=1
 		fi
-	elif [[ "$FILE" =~ \.sh$|bash$ ]]; then
+	elif [[ "$FILE" =~ .+\.(sh|bash|dash|ksh|ash|bats)$ ]]; then
 		echo "$FILE: missing shebang"
 		exit_status=1
 	fi


### PR DESCRIPTION
Added the ability to use optional shellcheck checks.

Testing Script:

```bash
#!/usr/bin/env bash

yo="a"
[ -z "$yo" ]

which ls
```

Testing pre-commit config:

```yaml
---
repos:
  - repo: local
    hooks:
      - id: shellcheck
        name: Shellcheck Bash Linter
        description: Performs linting on bash scripts
        entry: ../pre-commit/hooks/shellcheck.sh
        language: script
        # args: ["--enable require-variable-braces,deprecate-which"] # comment and uncomment
```

---

logging the command that would be ran, forcing exit 1 to show the logs:

With:

```bash
pre-commit run -a
Shellcheck Bash Linter...................................................Failed
- hook id: shellcheck
- exit code: 1

shellcheck --enable="require-variable-braces,deprecate-which" "sample.sh"

In sample.sh line 4:
[ -z "$yo" ]
      ^-^ SC2250: Prefer putting braces around variable references even when not strictly required.
...
...
```

Without:

```bash
pre-commit run -a
Shellcheck Bash Linter...................................................Failed
- hook id: shellcheck
- exit code: 1

shellcheck "sample.sh"
```

`--enable` will only be ran if it's provided in the pre-commit config. This is to avoid issues with shellcheck before 0.7.0 when `--enable` was added