### PR TITLE
Support tfenv+tgenv

### DIFF
--- a/hooks/terraform-fmt.sh
+++ b/hooks/terraform-fmt.sh
@@ -8,5 +8,7 @@ set -e
 export PATH=$PATH:/usr/local/bin
 
 for file in "$@"; do
+  pushd "$(dirname "$file")"
   terraform fmt -write=true "$file"
+  popd
 done

--- a/hooks/terraform-validate.sh
+++ b/hooks/terraform-validate.sh
@@ -8,6 +8,8 @@ set -e
 export PATH=$PATH:/usr/local/bin
 
 for dir in $(echo "$@" | xargs -n1 dirname | sort -u | uniq); do
-  terraform init -backend=false $dir
-  terraform validate $dir
+  pushd "$dir"
+  terraform init -backend=false "$dir"
+  terraform validate "$dir"
+  pushd
 done

--- a/hooks/terraform-validate.sh
+++ b/hooks/terraform-validate.sh
@@ -11,5 +11,5 @@ for dir in $(echo "$@" | xargs -n1 dirname | sort -u | uniq); do
   pushd "$dir"
   terraform init -backend=false "$dir"
   terraform validate "$dir"
-  pushd
+  popd
 done

--- a/hooks/terragrunt-hclfmt.sh
+++ b/hooks/terragrunt-hclfmt.sh
@@ -8,5 +8,7 @@ set -e
 export PATH=$PATH:/usr/local/bin
 
 for file in "$@"; do
+  pushd "$(dirname "$file")"
   terragrunt hclfmt --terragrunt-hclfmt-file "$file"
+  popd
 done


### PR DESCRIPTION
Invoke terraform and terragrunt from the directory of the file being checked. This allows **tfenv** and **tgenv** to load the correct versions of terraform and terragrunt in a mixed-version repository.

This is for the same reasons as gruntwork-io/module-ci#150:
> tfenv loads the correct terraform version based on a file called .terraform_version in the present working directory. Prior to this change, terraform-update-variable would use the root of the cloned repo as the present working directory and select a potentially incompatible version of terraform.