### PR TITLE
Clean up tfenv+tgenv support

### DIFF
--- a/hooks/terraform-fmt.sh
+++ b/hooks/terraform-fmt.sh
@@ -8,7 +8,7 @@ set -e
 export PATH=$PATH:/usr/local/bin
 
 for file in "$@"; do
-  pushd "$(dirname "$file")"
+  pushd "$(dirname "$file")" >/dev/null
   terraform fmt -write=true "$(basename "$file")"
-  popd
+  popd >/dev/null
 done

--- a/hooks/terraform-fmt.sh
+++ b/hooks/terraform-fmt.sh
@@ -9,6 +9,6 @@ export PATH=$PATH:/usr/local/bin
 
 for file in "$@"; do
   pushd "$(dirname "$file")"
-  terraform fmt -write=true "$file"
+  terraform fmt -write=true "$(basename "$file")"
   popd
 done


### PR DESCRIPTION
The changes from #26 did not work for me.  Here are two
changes:

  - When traversing directories and running `terraform fmt` in each dir,
  reference the local file.
  - Do not print the pushd/popd stack to stdout