### PR TITLE
Run helmlint hook as single process

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -86,6 +86,7 @@
   entry: hooks/helmlint.sh
   language: script
   files: \.((ya?ml)|(tpl))$
+  require_serial: true
 
 - id: markdown-link-check
   name: markdown-link-check


### PR DESCRIPTION
By [default](https://pre-commit.com/#hooks-require_serial) `pre-commit` will execute `helmlint` in parallel, which due to current logic implemented by `helmlint` will result in linting same chart(s) multiple times.

Current flow:
```
pre-commit run --all-files --verbose                                                                                                                 Sat Aug 15 13:25[2/1044]
helmlint.................................................................Passed
- hook id: helmlint
- duration: 0.19s

==> Linting /Users/esolidarity/Projects/blog/helm-charts
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
==> Linting /Users/esolidarity/Projects/blog/helm-charts
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
==> Linting /Users/esolidarity/Projects/blog/helm-charts
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

With `require_serial: true`
```
pre-commit run --all-files --verbose                                                                                                         524ms  Sat Aug 15 13:25:52 2020
helmlint.................................................................Passed
- hook id: helmlint
- duration: 0.28s

==> Linting /Users/esolidarity/Projects/blog/helm-charts
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

charts directory for reference:
```
tree helm-charts/                                                                                                                            626ms  Sat Aug 15 13:27:10 2020
helm-charts/
├── Chart.yaml
├── charts
│   └── postgresql-8.0.0.tgz
├── deploy.sh
├── requirements.lock
├── requirements.yaml
├── secrets.yaml
├── templates
│   ├── _helpers.tpl
│   ├── backend-certificate.yaml
│   ├── backend-deployment.yaml
│   ├── backend-ingress.yaml
│   ├── backend-service.yaml
│   └── configmap.yaml
└── values.yaml
```