### PR TITLE
Store and return last failure from validate vs exit on first failure

### DIFF
--- a/hooks/terraform-validate.sh
+++ b/hooks/terraform-validate.sh
@@ -7,9 +7,18 @@ set -e
 # workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
 export PATH=$PATH:/usr/local/bin
 
+# Disable output not usually helpful when running in automation (such as guidance to run plan after init)
+export TF_IN_AUTOMATION=1
+
+# Store and return last failure from validate so this can validate every directory passed before exiting
+VALIDATE_ERROR=0
+
 for dir in $(echo "$@" | xargs -n1 dirname | sort -u | uniq); do
+  echo "--> Running 'terraform validate' in directory '$dir'"
   pushd "$dir" >/dev/null
-  terraform init -backend=false
-  terraform validate
+  terraform init -backend=false || VALIDATE_ERROR=$?
+  terraform validate || VALIDATE_ERROR=$?
   popd >/dev/null
 done
+
+exit ${VALIDATE_ERROR}


### PR DESCRIPTION
This PR accomplishes two things:

* Cleans up output on terraform-validate adding informative marker indicating directory in which a failure occurred, which is crucial when running this in CI against a repository with a dozen or more modules.
* Updates terraform-validate to correctly check each argument passed in by pre-commit rather than exiting on the first failure encountered.
