### PR TITLE
Update terraform-fmt to match terraform-validate

### DIFF
--- a/hooks/terraform-fmt.sh
+++ b/hooks/terraform-fmt.sh
@@ -7,8 +7,14 @@ set -e
 # workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
 export PATH=$PATH:/usr/local/bin
 
-for file in "$@"; do
-  pushd "$(dirname "$file")" >/dev/null
-  terraform fmt -write=true "$(basename "$file")"
+# Store and return last failure from fmt so this can validate every directory passed before exiting
+FMT_ERROR=0
+
+for dir in $(echo "$@" | xargs -n1 dirname | sort -u | uniq); do
+  echo "--> Running 'terraform fmt' in directory '$dir'"
+  pushd "$dir" >/dev/null
+  terraform fmt -write=true || FMT_ERROR=$?
   popd >/dev/null
 done
+
+exit ${FMT_ERROR}

--- a/hooks/terraform-fmt.sh
+++ b/hooks/terraform-fmt.sh
@@ -10,11 +10,8 @@ export PATH=$PATH:/usr/local/bin
 # Store and return last failure from fmt so this can validate every directory passed before exiting
 FMT_ERROR=0
 
-for dir in $(echo "$@" | xargs -n1 dirname | sort -u | uniq); do
-  echo "--> Running 'terraform fmt' in directory '$dir'"
-  pushd "$dir" >/dev/null
-  terraform fmt -write=true || FMT_ERROR=$?
-  popd >/dev/null
+for file in "$@"; do
+  terraform fmt -diff -check "$file" || FMT_ERROR=$?
 done
 
 exit ${FMT_ERROR}


### PR DESCRIPTION
This PR updates the `terraform-fmt` hook as follows:

1. Run with `-diff -check` so the differences are printed, rather than made on disk.
1. Instead of exiting on the first error, save the exit codes, and print out all `fmt` errors before exiting.

These changes are very similar to https://github.com/gruntwork-io/pre-commit/pull/45.