### PR TITLE
Add tfsec

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -102,3 +102,12 @@
   entry: ./hooks/check_skip_env.py
   language: script
   files: \.go$
+
+- id: tfsec
+  name: tfsec
+  description: Security scanner for your Terraform code
+  entry: hooks/tfsec.sh
+  language: script
+  files: \.tf$
+  exclude: \.+.terraform\/.*$
+  require_serial: true

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ supported hooks are:
 * **terraform-validate**: Automatically run `terraform validate` on all Terraform code (`*.tf` files).
 * **terragrunt-hclfmt**: Automatically run `terragrunt hclfmt` on all Terragrunt configurations.
 * **tflint**: Automatically run [`tflint`](https://github.com/terraform-linters/tflint) on all Terraform code (`*.tf` files).
+* **tfsec**: Automatically run [`tfsec`](https://github.com/tfsec/tfsec) on all Terraform code (`*.tf` files).
 * **shellcheck**: Run [`shellcheck`](https://www.shellcheck.net/) to lint files that contain a bash [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)).
 * **gofmt**: Automatically run `gofmt` on all Golang code (`*.go` files).
 * **goimports**: Automatically run `goimports` on all Golang code (`*.go` files).

--- a/hooks/tfsec.sh
+++ b/hooks/tfsec.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+# OSX GUI apps do not pick up environment variables the same way as Terminal apps and there are no easy solutions,
+# especially as Apple changes the GUI app behavior every release (see https://stackoverflow.com/q/135688/483528). As a
+# workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
+export PATH=$PATH:/usr/local/bin
+
+dirs=$(echo $@ | xargs -n1 dirname | uniq)
+
+for dir in $dirs; do
+  tfsec --concise-output $dir
+done


### PR DESCRIPTION
This PR adds [tfsec](https://github.com/tfsec/tfsec) as a hook.

Since `tfsec` works with folders, not files, I had to extract directory paths from file paths. `uniq` removes duplicate paths, and `require_serial: true` disables parallelism and also reduces duplicates eventually.

Tested with `pre-commit try-repo`.