### PR TITLE
clean up PATH after changing it

### DIFF
--- a/hooks/terraform-fmt.sh
+++ b/hooks/terraform-fmt.sh
@@ -5,6 +5,7 @@ set -e
 # OSX GUI apps do not pick up environment variables the same way as Terminal apps and there are no easy solutions,
 # especially as Apple changes the GUI app behavior every release (see https://stackoverflow.com/q/135688/483528). As a
 # workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
+original_path=$PATH
 export PATH=$PATH:/usr/local/bin
 
 # Store and return last failure from fmt so this can validate every directory passed before exiting
@@ -13,5 +14,8 @@ FMT_ERROR=0
 for file in "$@"; do
   terraform fmt -diff -check "$file" || FMT_ERROR=$?
 done
+
+# reset path to the original value
+export PATH=$original_path
 
 exit ${FMT_ERROR}


### PR DESCRIPTION
Adding to the path without warning the user seems a little invasive.  Can we just save the original value and change it back after our new value is done being used?