### PR TITLE
Initialise tflint to install plugins

### DIFF
--- a/hooks/tflint.sh
+++ b/hooks/tflint.sh
@@ -7,6 +7,9 @@ set -e
 # workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
 export PATH=$PATH:/usr/local/bin
 
+# Install any plugins defined in .tflint.hcl
+tflint --init
+
 for file in "$@"; do
   tflint $file
 done


### PR DESCRIPTION
If `.tflint.hcl` has any plugins defined, the pre-commit hook will fail without human intervention. That's less than ideal when pre-commits are thought to be self contained, so initialise the plugins on each run. If they're installed, it's a single output line.