### PR TITLE
Change the way `go fmt` is executed

### DIFF
--- a/hooks/gofmt.sh
+++ b/hooks/gofmt.sh
@@ -9,5 +9,5 @@ export PATH=$PATH:/usr/local/bin
 
 
 for file in "$@"; do
-  go fmt "./$(dirname "$file")"
+  go fmt "$file"
 done


### PR DESCRIPTION
Since `$@` contains a filtered list of all `*.go` files that are staged for the commit, calling `go fmt` on them individually stops the error being thrown when trying to run `go fmt` against a subdirectory, from a directory which does not contain a `go.mod` file

<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This is one potential workaround for the issue described by me in issue #67

### Documentation

<!--
  If this is a feature PR, then where is it documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

<!-- Important: Did you make any backward incompatible changes? If yes, then you must write a migration guide! -->

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [n/a] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [n/a] Run the relevant tests successfully.

## Related Issues
Fixes #67 
<!--
  Link to related issues, and issues fixed or partially addressed by this PR.
  e.g. Fixes #1234
  e.g. Addresses #1234
  e.g. Related to #1234
-->
