### PR TITLE
* Add hook for packer fmt

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,6 +18,14 @@
   exclude: \.+.terraform\/.*$
   require_serial: true
 
+- id: packer-fmt
+  name: Packer fmt
+  description: Rewrites all Packer configuration files to a canonical format
+  entry: hooks/packer-fmt.sh
+  language: script
+  files: (\.pkr\.(hcl|json)|\.pkrvars\.hcl)$
+  require_serial: true
+
 - id: packer-validate
   name: Packer validate
   description: Validates all Packer configuration files

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ supported hooks are:
 
 * **terraform-fmt**: Automatically run `terraform fmt` on all Terraform code (`*.tf` files).
 * **terraform-validate**: Automatically run `terraform validate` on all Terraform code (`*.tf` files).
+* **packer-fmt**: Automatically run `packer fmt` on all Packer code (`*.pkr.*` files).
 * **packer-validate**: Automatically run `packer validate` on all Packer code (`*.pkr.*` files).
 * **terragrunt-hclfmt**: Automatically run `terragrunt hclfmt` on all Terragrunt configurations.
 * **tflint**: Automatically run [`tflint`](https://github.com/terraform-linters/tflint) on all Terraform code (`*.tf` files).

--- a/hooks/packer-fmt.sh
+++ b/hooks/packer-fmt.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+# OSX GUI apps do not pick up environment variables the same way as Terminal apps and there are no easy solutions,
+# especially as Apple changes the GUI app behavior every release (see https://stackoverflow.com/q/135688/483528). As a
+# workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
+original_path=$PATH
+export PATH=$PATH:/usr/local/bin
+
+# Store and return last failure from fmt so this can validate every directory passed before exiting
+FMT_ERROR=0
+
+for file in "$@"; do
+  packer fmt -diff -check "$file" || FMT_ERROR=$?
+done
+
+# reset path to the original value
+export PATH=$original_path
+
+exit ${FMT_ERROR}


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

Creates a hook for running packer fmt similar to the hook for running terraform fmt.

### Documentation

Updated README.md to describe the new hook.



## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [ X] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [ X] Update the docs.
- [X ] Keep the changes backward compatible where possible.
- [ ?] Run the pre-commit checks successfully.
- [X ] Run the relevant tests successfully.
- [ X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Related Issues
NA
