### PR TITLE
Amend README with how to configure shellcheck in addition to the pre-…

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,7 @@ helm lint -f values.yaml -f linter_values.yaml .
 
 ## Shellcheck Arguments
 
-The pre-commit hook for `shellcheck` accepts optional features as arguments using the `--enable` flag. For any
-additional entries set them in a `.shellcheckrc` within the project root.
+The pre-commit hook for `shellcheck` accepts optional features as arguments using the `--enable` flag.
 
 ```yaml
 repos:
@@ -142,6 +141,7 @@ repos:
         args: ["--enable require-variable-braces,deprecate-which"]
 ```
 
+For any additional entries set them in a `.shellcheckrc` within the project root.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ helm lint -f values.yaml -f linter_values.yaml .
 
 ## Shellcheck Arguments
 
-To enable optional shellcheck features you can use the `--enable` flag.
-Other shellcheck flags can not be passed through.
+The pre-commit hook for `shellcheck` accepts optional features as arguments using the `--enable` flag. For any
+additional entries set them in a `.shellcheckrc` within the project root.
 
 ```yaml
 repos:

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ helm lint -f values.yaml -f linter_values.yaml .
 
 ## Shellcheck Arguments
 
-The pre-commit hook for `shellcheck` accepts optional features as arguments using the `--enable` flag.
+To enable optional shellcheck features you can use the `--enable` flag.
 
 ```yaml
 repos:


### PR DESCRIPTION
## Description

Amends `README.md` with information on how to configure `shellcheck` beyond the `--enable` flag

resolves #79 

### Documentation

Updated README.md to describe that `.shellcheckrc` can be used in addition to the `--enable` flag.

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Related Issues