### PR TITLE
Ignore hash links

### DIFF
--- a/hooks/mdlink-check.sh
+++ b/hooks/mdlink-check.sh
@@ -15,6 +15,8 @@ fi
 
 # This is the recommended way to set the project root for properly resolving absolute paths. See
 # https://github.com/tcort/markdown-link-check/issues/16 for more info.
+# markdown-link-check 3.10 introduced checking anchors, which does not work witihn the same file. See
+# https://github.com/tcort/markdown-link-check/issues/195
 TMP_CONFIG="$(mktemp)"
 cat > "$TMP_CONFIG" <<EOF
 {
@@ -23,7 +25,12 @@ cat > "$TMP_CONFIG" <<EOF
       "pattern": "^/",
       "replacement": "file://$(pwd)/"
     }
-  ]
+  ],
+  "ignorePatterns": [
+    {
+      "pattern": "^#"
+    }
+  ]  
 }
 EOF
 


### PR DESCRIPTION
## Description

Validation of links to internal anchors was introduced to [`markdown-link-check`](https://github.com/tcort/markdown-link-check) in v3.10. Unfortunately this does not work with anchors created by HTML anchor tags, which is commonly used.
This change makes `markdown-link-check` ignore these links, which was the behaviour in previous versions.

