### PR TITLE
Add sentinel fmt hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -110,3 +110,11 @@
   entry: ./hooks/check_skip_env.py
   language: script
   files: \.go$
+
+- id: sentinel-fmt
+  name: Sentinel fmt
+  description: Rewrites all Sentinel configuration files to a canonical format
+  entry: hooks/sentinel-fmt.sh
+  language: script
+  files: \.sentinel$
+  require_serial: true

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ supported hooks are:
 * **helmlint** Automatically run [`helm lint`](https://helm.sh/docs/helm/helm_lint/) on your Helm chart files. [See caveats here](#helm-lint-caveats).
 * **markdown-link-check** Automatically run [markdown-link-check](https://github.com/tcort/markdown-link-check) on
   markdown doc files.
+* **sentinel-fmt**: Automatically run `sentinel fmt` on all Sentinel code (`*.sentinel.*` files).
+
 
 
 

--- a/hooks/sentinel-fmt.sh
+++ b/hooks/sentinel-fmt.sh
@@ -1,0 +1,22 @@
+
+#!/usr/bin/env bash
+
+set -e
+
+# OSX GUI apps do not pick up environment variables the same way as Terminal apps and there are no easy solutions,
+# especially as Apple changes the GUI app behavior every release (see https://stackoverflow.com/q/135688/483528). As a
+# workaround to allow GitHub Desktop to work, add this (hopefully harmless) setting here.
+original_path=$PATH
+export PATH=$PATH:/usr/local/bin
+
+# Store and return last failure from fmt so this can validate every directory passed before exiting
+FMT_ERROR=0
+
+for file in "$@"; do
+  sentinel fmt -diff -check "$file" || FMT_ERROR=$?
+done
+
+# reset path to the original value
+export PATH=$original_path
+
+exit ${FMT_ERROR}


### PR DESCRIPTION
## Description

Creates a hook for running sentinel fmt similar to the hook for running terraform fmt.

resolves #88

### Documentation

Updated README.md to describe the new hook.

## TODOs

Please ensure all of these TODOs are completed before asking for a review.
[ X] Ensure the branch is named correctly with the issue number. e.g: feature/new-vpc-endpoints-955 or bug/missing-count-param-434.
[ X] Update the docs.
[X ] Keep the changes backward compatible where possible.
[ ?] Run the pre-commit checks successfully.
[X ] Run the relevant tests successfully.
[ X] Ensure any 3rd party code adheres with our license policy or delete this line if its not applicable.

## Related Issues

N/A
