### PR TITLE
Added support for markdown-link-check options

### DIFF
--- a/hooks/mdlink-check.sh
+++ b/hooks/mdlink-check.sh
@@ -13,6 +13,16 @@ if ! command -v markdown-link-check; then
   exit 1
 fi
 
+# Parse arguments and separate files from markdown-link-check options
+ARGS=()
+FILES=()
+while [[ $# -gt 0 ]]; do case "$1" in
+	-c | --config   | -a | --alive | -r | --retry) ARGS+=("$1" "$2"); shift; ;;
+	-p | --progress | -q | --quiet | -v | --verbose) ARGS+=("$1"); ;;
+  *) FILES+=("$1"); ;;
+esac; shift; done;
+
+
 # This is the recommended way to set the project root for properly resolving absolute paths. See
 # https://github.com/tcort/markdown-link-check/issues/16 for more info.
 # markdown-link-check 3.10 introduced checking anchors, which does not work witihn the same file. See
@@ -34,6 +44,7 @@ cat > "$TMP_CONFIG" <<EOF
 }
 EOF
 
-for file in "$@"; do
-  markdown-link-check -c "$TMP_CONFIG" "$file"
+for file in "${FILES[@]}"; do
+  # shellcheck disable=SC2068
+  markdown-link-check -c "$TMP_CONFIG" ${ARGS[@]} "$file"
 done


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

Added support for markdown-link-check options

### Documentation

Use the pre-commit documentation for information on hook arguments

<!-- Important: Did you make any backward incompatible changes? If yes, then you must write a migration guide! -->

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Related Issues

Fixes #78
