### PR TITLE
tflint has deprecated the 'tflint FILE/DIR' syntax

### DIFF
--- a/hooks/tflint.sh
+++ b/hooks/tflint.sh
@@ -26,5 +26,5 @@ done
 
 for file in "${FILES[@]}"
 do
-  tflint "${ARGS[@]}" "$file"
+  tflint "${ARGS[@]}" --chdir "$(dirname $file)" --filter "$(basename $file)"
 done

--- a/hooks/tflint.sh
+++ b/hooks/tflint.sh
@@ -26,5 +26,5 @@ done
 
 for file in "${FILES[@]}"
 do
-  tflint "${ARGS[@]}" --chdir "$(dirname $file)" --filter "$(basename $file)"
+  tflint "${ARGS[@]}" --chdir "$(dirname "$file")" --filter "$(basename "$file")"
 done


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

`tflint` version `v0.46.0` deprecates support for the `tflint FILE/DIR` command-line syntax.  It has been replaced with `tflint --chdir DIR --filter FILE`.  See https://github.com/terraform-linters/tflint/pull/1687 for more details.

### Documentation

<!--
  If this is a feature PR, then where is it documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

<!-- Important: Did you make any backward incompatible changes? If yes, then you must write a migration guide! -->

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [ ] Keep the changes backward compatible where possible.



## Related Issues

Fixes #94

<!--
  Link to related issues, and issues fixed or partially addressed by this PR.
  e.g. Fixes #1234
  e.g. Addresses #1234
  e.g. Related to #1234
-->
