### PR TITLE
Switch to file directory for terraform-fmt check

### DIFF
--- a/hooks/terraform-fmt.sh
+++ b/hooks/terraform-fmt.sh
@@ -12,7 +12,9 @@ export PATH=$PATH:/usr/local/bin
 FMT_ERROR=0
 
 for file in "$@"; do
-  terraform fmt -diff -check "$file" || FMT_ERROR=$?
+  pushd "$(dirname "$file")" >/dev/null
+  terraform fmt -diff -check "$(basename "$file")" || FMT_ERROR=$?
+  popd >/dev/null
 done
 
 # reset path to the original value


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

### Problem

When using [`tfenv`](https://github.com/tfutils/tfenv), `terraform` executable might resolve to different Terraform versions, depending on the directory where it runs (e.g. via using [`.terraform-version`](https://github.com/tfutils/tfenv#terraform-version-file) files).
At the moment, the `terraform-fmt` check runs `terraform fmt` from the repository root, and in some cases (e.g. when  all Terraform configuration along with `.terraform-version` is in a subfolder) it might even mean that no valid Terraform version is configured.

### Proposed solution

For `terraform-fmt` check, switch to the directory of the Terraform file we're checking (similarly to what happens in [terraform-hclfmt](https://github.com/gruntwork-io/pre-commit/blob/master/hooks/terragrunt-hclfmt.sh#L11-L13) and [terraform-validate](https://github.com/gruntwork-io/pre-commit/blob/master/hooks/terraform-validate.sh#L18-L21) checks). This will ensure that the right Terraform version is picked up if tools like `tfenv` are used. 

### Documentation

<!--
  If this is a feature PR, then where is it documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

<!-- Important: Did you make any backward incompatible changes? If yes, then you must write a migration guide! -->

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [ ] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [ ] Update the docs.
- [ ] Keep the changes backward compatible where possible.
- [ ] Run the pre-commit checks successfully.
- [ ] Run the relevant tests successfully.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Related Issues

<!--
  Link to related issues, and issues fixed or partially addressed by this PR.
  e.g. Fixes #1234
  e.g. Addresses #1234
  e.g. Related to #1234
-->
