### PR TITLE
Feature/add git root keyword 102

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,46 @@ repos:
         args: ["--enable require-variable-braces,deprecate-which"]
 ```
 
+## tflint Caveats
+
+### Using the `--config` argument
+
+With the introduction of `--chdir` into tflint, the `--config` argument is now bound to whatever subdirectory you are
+running the check against.  For mono-repos this isn't ideal as you may have a central configuration file you'd like to
+use.  If this matches your use-case, you can specify the placeholder `__GIT_DIR__` value in the `--config` argument 
+that will evaluate to the root of the repository you are in.
+
+```yaml
+repos:
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: <VERSION>
+    hooks:
+    - id: tflint
+      args:
+        - "--config=__GIT_DIR__/.tflint.hcl"
+```
+
+#### Changing the placeholder value
+
+You can change the value of the placeholder by populating the `PRECOMMIT_TFLINT_REPO_ROOT_KEYWORD` environment variable.
+
+```bash
+export PRECOMMIT_TFLINT_REPO_ROOT_KEYWORD=__foo__
+
+cat <<EOF > .pre-commit-config.yaml
+---
+repos:
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: v0.1.22
+    hooks:
+    - id: terragrunt-hclfmt
+    - id: tflint
+      args:
+        - "--config=__foo__/.tflint.hcl"
+EOF
+
+pre-commit run
+```
 
 ## License
 


### PR DESCRIPTION

<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

When operating in a monorepo the new functionality of tflint (`--chdir`) breaks config file path by changing the current working directory when tflint runs.  This commit patches this gap by allowing a user to provide __GIT_ROOT__ or populate a environment variable with a custom string and when the `--config` argument is is found it replaces that keyword with the repository root (pwd in the case of pre-commit).

I've also re-positioned the init call and passed the arguments to it as it simply looked for the default `.tflint.hcl`.

### Documentation

<!--
  If this is a feature PR, then where is it documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->
I've updated the README.md with the caveats that this introduces and how to use it.

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [X] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [X] Update the docs.
- [X] Keep the changes backward compatible where possible.
- [X] Run the pre-commit checks successfully.
- [X] Run the relevant tests successfully.
- [X] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Related Issues
Fixes #102 
