### PR TITLE
Fixing TFLint section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ repos:
 
 With the introduction of `--chdir` into tflint, the `--config` argument is now bound to whatever subdirectory you are
 running the check against.  For mono-repos this isn't ideal as you may have a central configuration file you'd like to
-use.  If this matches your use-case, you can specify the placeholder `__GIT_DIR__` value in the `--config` argument 
+use.  If this matches your use-case, you can specify the placeholder `__GIT_ROOT__` value in the `--config` argument 
 that will evaluate to the root of the repository you are in.
 
 ```yaml
@@ -161,7 +161,7 @@ repos:
     hooks:
     - id: tflint
       args:
-        - "--config=__GIT_DIR__/.tflint.hcl"
+        - "--config=__GIT_ROOT__/.tflint.hcl"
 ```
 
 #### Changing the placeholder value


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

README made reference to the wrong default value of the root keyword.

<!--
  If this is a feature PR, then where is it documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

<!-- Important: Did you make any backward incompatible changes? If yes, then you must write a migration guide! -->

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Related Issues

<!--
  Link to related issues, and issues fixed or partially addressed by this PR.
  e.g. Fixes #1234
  e.g. Addresses #1234
  e.g. Related to #1234
-->
