### PR TITLE
fix: replace deprecated --terragrunt-hclfmt-file flag

### DIFF
--- a/hooks/terragrunt-hclfmt.sh
+++ b/hooks/terragrunt-hclfmt.sh
@@ -9,6 +9,6 @@ export PATH=$PATH:/usr/local/bin
 
 for file in "$@"; do
   pushd "$(dirname "$file")" >/dev/null
-  terragrunt hclfmt --terragrunt-hclfmt-file "$(basename "$file")"
+  terragrunt hclfmt --file "$(basename "$file")"
   popd >/dev/null
 done


### PR DESCRIPTION
Fix the following warning:

```

- hook id: terragrunt-hclfmt
- duration: 0.48s

08:57:07.805 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=.terraform.lock.hcl` instead.
08:57:07.909 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=.terraform.lock.hcl` instead.
08:57:08.022 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=terragrunt.hcl` instead.
08:57:08.111 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=.terraform.lock.hcl` instead.
08:57:07.812 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=.terraform.lock.hcl` instead.
08:57:07.933 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=.terraform.lock.hcl` instead.
08:57:08.029 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=.terraform.lock.hcl` instead.
08:57:08.158 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=.terraform.lock.hcl` instead.
08:57:07.798 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=.terraform.lock.hcl` instead.
08:57:07.922 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=env.hcl` instead.
08:57:08.025 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=.terraform.lock.hcl` instead.
08:57:08.155 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=terragrunt.hcl` instead.
08:57:07.804 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=terragrunt.hcl` instead.
08:57:07.919 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=terragrunt.hcl` instead.
08:57:08.037 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=.tflint.hcl` instead.
08:57:08.165 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=terragrunt.hcl` instead.
08:57:07.807 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=.terraform.lock.hcl` instead.
08:57:07.910 WARN   The `--terragrunt-hclfmt-file` flag is deprecated and will be removed in a future version. Use `--file=terragrunt.hcl` instead.
```