### PR TITLE
Update sentinel logic

### DIFF
--- a/hooks/sentinel-fmt.sh
+++ b/hooks/sentinel-fmt.sh
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env bash
 
 set -e
@@ -13,7 +12,7 @@ export PATH=$PATH:/usr/local/bin
 FMT_ERROR=0
 
 for file in "$@"; do
-  sentinel fmt -diff -check "$file" || FMT_ERROR=$?
+  sentinel fmt -check "$file" || FMT_ERROR=$?
 done
 
 # reset path to the original value


### PR DESCRIPTION
## Description

Fixes #121. Removes '-diff' from sentinel as this is no longer a supported flag for fmt. Also makes the shell script executable and fixes the shebang to allow proper execution.

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
