### PR TITLE
fix(terragrunt): change terragrunt format for the non-deprecated command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ supported hooks are:
 * **terraform-fmt**: Automatically run `terraform fmt` on all Terraform code (`*.tf` files).
 * **terraform-validate**: Automatically run `terraform validate` on all Terraform code (`*.tf` files).
 * **packer-validate**: Automatically run `packer validate` on all Packer code (`*.pkr.*` files).
-* **terragrunt-hclfmt**: Automatically run `terragrunt hclfmt` on all Terragrunt configurations.
+* **terragrunt-hclfmt**: Automatically run `terragrunt hcl format` on all Terragrunt configurations.
 * **tflint**: Automatically run [`tflint`](https://github.com/terraform-linters/tflint) on all OpenTofu/Terraform code (`*.tf`, `*.tofu` files).
 * **shellcheck**: Run [`shellcheck`](https://www.shellcheck.net/) to lint files that contain a bash [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)).
 * **gofmt**: Automatically run `gofmt` on all Golang code (`*.go` files).

--- a/hooks/terragrunt-hclfmt.sh
+++ b/hooks/terragrunt-hclfmt.sh
@@ -9,6 +9,6 @@ export PATH=$PATH:/usr/local/bin
 
 for file in "$@"; do
   pushd "$(dirname "$file")" >/dev/null
-  terragrunt hclfmt --file "$(basename "$file")"
+  terragrunt hcl format --file "$(basename "$file")"
   popd >/dev/null
 done


### PR DESCRIPTION
## Description

Change terragrunt format for the non-deprecated command
hclfmt -> hcl format

## Related Issues
Fixes #131