### PR TITLE
Allow using latest terragrunt build

### DIFF
--- a/hooks/terragrunt-hcl-fmt.sh
+++ b/hooks/terragrunt-hcl-fmt.sh
@@ -10,14 +10,15 @@ export PATH=$PATH:/usr/local/bin
 check_terragrunt_version() {
   local minimum_supported_version="0.77.22"
   local current_version
+    
+  local version_output
+  version_output=$(terragrunt --version 2>/dev/null)
 
-  if ! command -v terragrunt >/dev/null 2>&1; then
-    echo "Warning: terragrunt command not found. Proceeding anyway..." >&2
-
+  if [[ "$version_output" == *"latest"* ]]; then
     return 0
   fi
 
-  if ! current_version=$(terragrunt --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1); then
+  if ! current_version=$(echo "$version_output" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1); then
     echo "Warning: Could not determine terragrunt version. Proceeding anyway..." >&2
 
     return 0


### PR DESCRIPTION
The current checks for supported version fails if terragrunt has been built from source. This is because the command `terragrunt --version` outputs "terragrunt version latest" which fails the comparisons and stops the pre-commit hook from running.

<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  If this is a feature PR, then where is it documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

<!-- Important: Did you make any backward incompatible changes? If yes, then you must write a migration guide! -->

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [ ] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [ ] Update the docs.
- [ ] Keep the changes backward compatible where possible.
- [ ] Run the pre-commit checks successfully.
- [ ] Run the relevant tests successfully.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Related Issues

<!--
  Link to related issues, and issues fixed or partially addressed by this PR.
  e.g. Fixes #1234
  e.g. Addresses #1234
  e.g. Related to #1234
-->
