### PR TITLE
fix: use new CLI command

### DIFF
--- a/hooks/terragrunt-hclfmt.sh
+++ b/hooks/terragrunt-hclfmt.sh
@@ -9,6 +9,6 @@ export PATH=$PATH:/usr/local/bin
 
 for file in "$@"; do
   pushd "$(dirname "$file")" >/dev/null
-  terragrunt hclfmt --file "$(basename "$file")"
+  terragrunt hcl fmt --file "$(basename "$file")"
   popd >/dev/null
 done


### PR DESCRIPTION
Fixes https://github.com/gruntwork-io/pre-commit/issues/140

## Description

This fixes the deprecation of the flags, pushed by terragrunt 0.90.0: 
```
ERROR  flag `--file` is not a valid global flag. Did you mean to use `hcl format --file`
```